### PR TITLE
PR: Fix colour URL encoding regression and delayed queue head-of-line blocking

### DIFF
--- a/JsonDataProvider/JsonDataProvider.cs
+++ b/JsonDataProvider/JsonDataProvider.cs
@@ -34,6 +34,7 @@ namespace JsonDataProviderNs
         private int _retrievingData = 0;
         private readonly object _pathLock = new object();
         private readonly object _ctsLock = new object();
+        private const int MaxRows = 10000; // Maximum number of source rows processed (grouping limit)
         private Json.Path.JsonPath _compiledPath;
         private string _compiledPathSource = string.Empty;
 
@@ -246,7 +247,7 @@ namespace JsonDataProviderNs
                     Data = new List<string>();
                     return;
                 }
-                var results = path.Evaluate(_document.RootElement.AsNode()).Matches.Take(100 * (_groupBy <= 0 ? 1 : _groupBy)).Select(x => x.Value.ToString()).ToList();
+                var results = path.Evaluate(_document.RootElement.AsNode()).Matches.Take(MaxRows * (_groupBy <= 0 ? 1 : _groupBy)).Select(x => x.Value.ToString()).ToList();
 
                 if (_groupBy > 1)
                 {

--- a/UTCGoogleSheetsDataProvider/GoogleSheetsDataProvider.cs
+++ b/UTCGoogleSheetsDataProvider/GoogleSheetsDataProvider.cs
@@ -386,6 +386,8 @@ namespace UTCGoogleSheetsDataProvider
                 _cancellationTokenSource.Dispose();
                 _cancellationTokenSource = new CancellationTokenSource();
             }
+            _lastModifiedCache.TryRemove(SheetKey, out _);
+            _spreadsheetCache.TryRemove(SheetKey, out _);
             _ = UpdateData();
         }));
 

--- a/UTCXLSXDataProvider/ExcelDataProvider.cs
+++ b/UTCXLSXDataProvider/ExcelDataProvider.cs
@@ -9,6 +9,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
@@ -25,6 +27,7 @@ namespace UTCGoogleSheetsDataProvider
         private static readonly Regex ColumnRegex = new Regex("^[A-Z]+$", RegexOptions.Compiled);
         private readonly DispatcherTimer _refreshTimer;
         private int _period = 1000;
+        private readonly SemaphoreSlim _reloadLock = new SemaphoreSlim(1, 1);
 
         public object PreviewKeyUp { get; set; }
         public object GotFocus { get; set; }
@@ -86,116 +89,151 @@ namespace UTCGoogleSheetsDataProvider
         {
             get
             {
-                _hasError = false;
+                return Cached;
+            }
+        }
+
+        private void ReloadInBackground()
+        {
+            if (string.IsNullOrWhiteSpace(FilePath))
+                return;
+
+            if (!File.Exists(FilePath))
+            {
+                _hasError = true;
+                Cached = Array.Empty<string>();
+                RowsCount = 0;
+                RaisePropertyChanged(nameof(Values));
+                return;
+            }
+
+            var fileInfo = new FileInfo(FilePath);
+            if (fileInfo.LastWriteTimeUtc <= _lastModified)
+                return;
+
+            if (!_reloadLock.Wait(0))
+                return;
+
+            var timestamp = fileInfo.LastWriteTimeUtc;
+            Task.Run(() =>
+            {
+                string[] result = null;
                 try
                 {
+                    result = ReloadValues();
+                }
+                catch
+                {
+                    result = null;
+                }
+                finally
+                {
+                    _reloadLock.Release();
+                }
 
-                    if (File.Exists(FilePath))
+                var dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher == null)
+                    return;
+
+                Action apply = () =>
+                {
+                    if (result != null)
                     {
-                        var fileInfo = new FileInfo(FilePath);
-                        if (fileInfo.LastWriteTimeUtc > _lastModified)
-                        {
-                            _lastModified = fileInfo.LastWriteTimeUtc;
-
-                            using (var xls = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                            {
-                                try
-                                {
-                                    using (var reader = ExcelReaderFactory.CreateReader(xls))
-                                    {
-                                        List<string> results = new List<string>();
-                                        int sheet = 0;
-                                        int startColIndex = ParseExcelColumn(StartCol);
-                                        int endColIndex = ParseExcelColumn(EndCol);
-                                        do
-                                        {
-                                            int row = 0;
-                                            int sheetIndex = 0;
-                                            if ((int.TryParse(SheetIndex, out sheetIndex) && sheet == sheetIndex) || reader.Name == SheetIndex)
-                                                while (reader.Read())
-                                                {
-                                                    if (row >= StartRow)
-                                                    {
-                                                        var safeStartCol = Math.Max(0, startColIndex);
-                                                        var endExclusive = endColIndex >= 0
-                                                            ? Math.Min(reader.FieldCount, endColIndex + 1)
-                                                            : reader.FieldCount;
-                                                        StringBuilder lineBuilder = IsTable ? new StringBuilder() : null;
-                                                        for (int i = safeStartCol; i < endExclusive; i++)
-                                                        {
-                                                            var value = reader.GetValue(i)?.ToString() ?? "";
-                                                            if (IsTable)
-                                                            {
-                                                                if (lineBuilder.Length > 0)
-                                                                {
-                                                                    lineBuilder.Append('|');
-                                                                }
-                                                                lineBuilder.Append(value);
-                                                            }
-                                                            else
-                                                            {
-                                                                results.Add(value);
-                                                            }
-                                                        }
-                                                        if (IsTable)
-                                                            results.Add(lineBuilder?.ToString() ?? string.Empty);
-                                                    }
-                                                    row++;
-                                                    if (EndRow >= 0 && row > EndRow)
-                                                        break;
-                                                }
-                                            sheet++;
-                                        }
-                                        while (reader.NextResult());
-
-                                        Cached = results.ToArray();
-                                        RowsCount = Cached.Length;
-                                        RaisePropertyChanged(nameof(Values));
-                                        return Cached;
-                                    }
-                                }
-                                catch (ExcelReaderException ex)
-                                {
-                                    _hasError = true;
-                                    RowsCount = 0;
-                                    Cached = Array.Empty<string>();
-                                    RaisePropertyChanged(nameof(Values));
-                                    Debug.Print($"Error reading Excel file: {ex.Message}");
-                                    return Array.Empty<string>();
-                                }
-                                catch (Exception ex)
-                                {
-                                    _hasError = true;
-                                    RowsCount = 0;
-                                    Cached = Array.Empty<string>();
-                                    RaisePropertyChanged(nameof(Values));
-                                    Debug.Print($"Unexpected error: {ex.Message}");
-                                    return Array.Empty<string>();
-                                }
-                            }
-                        }
-                        else
-                            return Cached;
+                        _lastModified = timestamp;
+                        _hasError = false;
+                        Cached = result;
+                        RowsCount = result.Length;
                     }
                     else
                     {
                         _hasError = true;
-                        RowsCount = 0;
                         Cached = Array.Empty<string>();
-                        RaisePropertyChanged(nameof(Values));
-                        Debug.Print("File not found.");
-                        return Array.Empty<string>();
+                        RowsCount = 0;
+                    }
+                    RaisePropertyChanged(nameof(Values));
+                };
+
+                if (dispatcher.CheckAccess())
+                    apply();
+                else
+                    dispatcher.BeginInvoke(apply);
+            });
+        }
+
+        private string[] ReloadValues()
+        {
+            try
+            {
+                using (var xls = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    try
+                    {
+                        using (var reader = ExcelReaderFactory.CreateReader(xls))
+                        {
+                            List<string> results = new List<string>();
+                            int sheet = 0;
+                            int startColIndex = ParseExcelColumn(StartCol);
+                            int endColIndex = ParseExcelColumn(EndCol);
+                            do
+                            {
+                                int row = 0;
+                                int sheetIndex = 0;
+                                if ((int.TryParse(SheetIndex, out sheetIndex) && sheet == sheetIndex) || reader.Name == SheetIndex)
+                                    while (reader.Read())
+                                    {
+                                        if (row >= StartRow)
+                                        {
+                                            var safeStartCol = Math.Max(0, startColIndex);
+                                            var endExclusive = endColIndex >= 0
+                                                ? Math.Min(reader.FieldCount, endColIndex + 1)
+                                                : reader.FieldCount;
+                                            StringBuilder lineBuilder = IsTable ? new StringBuilder() : null;
+                                            for (int i = safeStartCol; i < endExclusive; i++)
+                                            {
+                                                var value = reader.GetValue(i)?.ToString() ?? "";
+                                                if (IsTable)
+                                                {
+                                                    if (lineBuilder.Length > 0)
+                                                    {
+                                                        lineBuilder.Append('|');
+                                                    }
+                                                    lineBuilder.Append(value);
+                                                }
+                                                else
+                                                {
+                                                    results.Add(value);
+                                                }
+                                            }
+                                            if (IsTable)
+                                                results.Add(lineBuilder?.ToString() ?? string.Empty);
+                                        }
+                                        row++;
+                                        if (EndRow >= 0 && row > EndRow)
+                                            break;
+                                    }
+                                sheet++;
+                            }
+                            while (reader.NextResult());
+
+                            return results.ToArray();
+                        }
+                    }
+                    catch (ExcelReaderException ex)
+                    {
+                        Debug.Print($"Error reading Excel file: {ex.Message}");
+                        return null;
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.Print($"Unexpected error: {ex.Message}");
+                        return null;
                     }
                 }
-                catch (Exception ex)
-                {
-                    _hasError = true;
-                    RowsCount = 0;
-                    Cached = Array.Empty<string>();
-                    RaisePropertyChanged(nameof(Values));
-                    Debug.Print($"An error occurred: {ex.Message}");
-                    return Array.Empty<string>();
-                }
+            }
+            catch (Exception ex)
+            {
+                Debug.Print($"An error occurred: {ex.Message}");
+                return null;
             }
         }
 
@@ -440,7 +478,7 @@ namespace UTCGoogleSheetsDataProvider
 
         private void RefreshTimer_Tick(object sender, EventArgs e)
         {
-            _ = Values;
+            ReloadInBackground();
         }
     }
 }

--- a/vMixAPI/State.cs
+++ b/vMixAPI/State.cs
@@ -550,6 +550,7 @@ namespace vMixAPI
             OnFunctionSend?.Invoke(this, new FunctionSendArgs() { Function = textParameters });
 
             string address = string.Format("http://{0}:{1}/api?", _ip, _port);
+            textParameters = textParameters.Replace("#", "%23");
             var url = address + textParameters;
 
             if (!StateFabrique.IsUrlValid(_ip, _port))

--- a/vMixController/Classes/Scripting/vMixControlButtonHelper.cs
+++ b/vMixController/Classes/Scripting/vMixControlButtonHelper.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Linq;
 using System.Xml;
 
 namespace vMixController.Classes.Scripting
@@ -90,7 +91,7 @@ namespace vMixController.Classes.Scripting
             bool hasErrors = false;
             vMixControlExpressionHelper.BuildInputMaps(doc, out var inputNumberByKey, out var inputKeyByNumber);
 
-            foreach (var command in _commands)
+            foreach (var command in _commands.ToList())
             {
                 if (!command.UseInActiveState)
                 {

--- a/vMixController/Classes/Scripting/vMixControlNewButtonCommand.cs
+++ b/vMixController/Classes/Scripting/vMixControlNewButtonCommand.cs
@@ -91,6 +91,31 @@ namespace vMixController.Classes.Scripting
             }
         }
 
+        private string _selectedName = "";
+
+        /// <summary>
+        /// Sets and gets the SelectedName property.
+        /// Changes to that property's value raise the PropertyChanged event. 
+        /// </summary>
+        public string SelectedName
+        {
+            get
+            {
+                return _selectedName;
+            }
+
+            set
+            {
+                if (_selectedName == value)
+                {
+                    return;
+                }
+
+                _selectedName = value;
+                RaisePropertyChanged(nameof(SelectedName));
+            }
+        }
+
         private int _inputNumber = -1;
 
         /// <summary>
@@ -355,6 +380,11 @@ namespace vMixController.Classes.Scripting
                 parameters.Add(Escape(SelectedIndex));
             }
 
+            if (Action.HasSelectedName)
+            {
+                parameters.Add(Escape(SelectedName));
+            }
+
             if (Action.HasDuration)
             {
                 parameters.Add(Escape(Duration));
@@ -451,6 +481,11 @@ namespace vMixController.Classes.Scripting
             {
                 if (currentParamIndex < parameters.Count)
                     cmd.SelectedIndex = Unescape(parameters[currentParamIndex++]);
+            }
+            if (cmd.Action.HasSelectedName)
+            {
+                if (currentParamIndex < parameters.Count)
+                    cmd.SelectedName = Unescape(parameters[currentParamIndex++]);
             }
             if (cmd.Action.HasDuration)
             {

--- a/vMixController/Classes/Scripting/vMixControlNewButtonHelper.cs
+++ b/vMixController/Classes/Scripting/vMixControlNewButtonHelper.cs
@@ -24,9 +24,10 @@ namespace vMixController.Classes.Scripting
         public string Channel { get; }
         public string Duration { get; }
         public string SelectedIndex { get; }
+        public string SelectedName { get; }
 
         public Func<string, string, string> Resolve { get; }
-        public XPathNewFormattingArgs(string inputKey, int inputNumber, string value, string index, string mix, string channel, string duration, Func<string, string, string> resolve = null)
+        public XPathNewFormattingArgs(string inputKey, int inputNumber, string value, string index, string selectedName, string mix, string channel, string duration, Func<string, string, string> resolve = null)
         {
             InputKey = inputKey;
             InputNumber = inputNumber;
@@ -35,6 +36,7 @@ namespace vMixController.Classes.Scripting
             Channel = channel;
             Duration = duration;
             SelectedIndex = index;
+            SelectedName = selectedName;
             Resolve = resolve;
         }
     }
@@ -78,7 +80,8 @@ namespace vMixController.Classes.Scripting
                 [nameof(XPathNewFormattingArgs.Mix)] = dataObject.Mix ?? string.Empty,
                 [nameof(XPathNewFormattingArgs.Channel)] = dataObject.Channel ?? string.Empty,
                 [nameof(XPathNewFormattingArgs.Duration)] = dataObject.Duration ?? string.Empty,
-                [nameof(XPathNewFormattingArgs.SelectedIndex)] = dataObject.SelectedIndex ?? string.Empty
+                [nameof(XPathNewFormattingArgs.SelectedIndex)] = dataObject.SelectedIndex ?? string.Empty,
+                [nameof(XPathNewFormattingArgs.SelectedName)] = dataObject.SelectedName ?? string.Empty
             };
 
             // 1. Обработка условий (if/else if/else)
@@ -325,7 +328,10 @@ namespace vMixController.Classes.Scripting
                         break;
                 }
                 CalculateExpression<string>(item.SelectedIndex, PopulateVariables, Exp_EvaluateFunction, out string index);
-                var args = new XPathNewFormattingArgs(expandedInputKey, inputNumber, value, index, item.Mix, item.Channel, item.Duration, (function, parameter) =>
+                CalculateExpression<string>(item.SelectedName, PopulateVariables, Exp_EvaluateFunction, out string selectedName);
+                if (string.IsNullOrEmpty(selectedName))
+                    selectedName = item.SelectedName;
+                var args = new XPathNewFormattingArgs(expandedInputKey, inputNumber, value, index, selectedName, item.Mix, item.Channel, item.Duration, (function, parameter) =>
                 {
                     switch (function)
                     {

--- a/vMixController/Classes/Scripting/vMixControlNewButtonHelper.cs
+++ b/vMixController/Classes/Scripting/vMixControlNewButtonHelper.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml;
 
@@ -248,7 +249,7 @@ namespace vMixController.Classes.Scripting
             bool hasErrors = false;
             vMixControlExpressionHelper.BuildInputMaps(doc, out var inputNumberByKey, out var inputKeyByNumber);
 
-            foreach (var command in _commands)
+            foreach (var command in _commands.ToList())
             {
                 if (!command.UseInActiveState)
                 {

--- a/vMixController/Classes/Scripting/vMixNewFunctionReference.cs
+++ b/vMixController/Classes/Scripting/vMixNewFunctionReference.cs
@@ -76,7 +76,20 @@ namespace vMixController.Classes.Scripting
 
         public string GetSignature()
         {
-            return "";
+            var parameters = new List<string>();
+            if (HasInput)
+                parameters.Add("Input");
+            if (HasValue)
+                parameters.Add("Value");
+            if (HasChannel)
+                parameters.Add("Channel");
+            if (HasMix)
+                parameters.Add("Mix");
+            if (HasDuration)
+                parameters.Add("Duration");
+            if (HasIndex)
+                parameters.Add("SelectedIndex");
+            return parameters.Count > 0 ? Function + "(" + string.Join(", ", parameters) + ")" : Function;
         }
 
     }

--- a/vMixController/Classes/Scripting/vMixNewFunctionReference.cs
+++ b/vMixController/Classes/Scripting/vMixNewFunctionReference.cs
@@ -35,6 +35,7 @@ namespace vMixController.Classes.Scripting
         public bool HasDuration { get; set; }
         public bool HasChannel { get; set; }
         public bool HasIndex { get; set; }
+        public bool HasSelectedName { get; set; }
         public bool IsBlock { get; set; }
 
         private string _formatString;
@@ -50,6 +51,7 @@ namespace vMixController.Classes.Scripting
                 HasMix = value.Contains("$Mix");
                 HasDuration = value.Contains("$Duration");
                 HasIndex = value.Contains("$SelectedIndex");
+                HasSelectedName = value.Contains("$SelectedName");
                 _formatString = value;
             }
         }
@@ -89,6 +91,8 @@ namespace vMixController.Classes.Scripting
                 parameters.Add("Duration");
             if (HasIndex)
                 parameters.Add("SelectedIndex");
+            if (HasSelectedName)
+                parameters.Add("SelectedName");
             return parameters.Count > 0 ? Function + "(" + string.Join(", ", parameters) + ")" : Function;
         }
 

--- a/vMixController/NewFunctions.xml
+++ b/vMixController/NewFunctions.xml
@@ -2024,7 +2024,7 @@ SelectedIndex or SelectedName can be used to select image.
 		<Description>Change Colour of Text in Title in HTML format (#xxxxxx)</Description>
 		<Function>SetTextColour</Function>
 		<ValueName>Colour</ValueName>
-		<FormatString>Function=SetTextColour&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetTextColour&amp;Input=$InputKey&amp;Value=$Value</FormatString>
 		<Category>Title</Category>
 	</vMixNewFunctionReference>
 

--- a/vMixController/NewFunctions.xml
+++ b/vMixController/NewFunctions.xml
@@ -55,7 +55,7 @@
 	<vMixNewFunctionReference>
 		<Description></Description>
 		<Function>HasVariable</Function>
-		<FormatString>Function=HasVariable&amp;$SelectedIndex</FormatString>
+		<FormatString>Function=HasVariable&amp;Value=$SelectedIndex</FormatString>
 		<Category>Native</Category>
 		<Native>true</Native>
 	</vMixNewFunctionReference>
@@ -63,7 +63,7 @@
 	<vMixNewFunctionReference>
 		<Description></Description>
 		<Function>ValueChanged</Function>
-		<FormatString>Function=ValueChanged&amp;$Value$InputKey</FormatString>
+		<FormatString>Function=ValueChanged&amp;Value=$Value&amp;Input=$InputKey</FormatString>
 		<Category>Native</Category>
 		<Native>true</Native>
 	</vMixNewFunctionReference>

--- a/vMixController/NewFunctions.xml
+++ b/vMixController/NewFunctions.xml
@@ -315,7 +315,7 @@
 		</Description>
 		<Function>SetText</Function>
 		<ValueName>Text</ValueName>
-		<FormatString>Function=SetText&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetText&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 		<DirectPath>Inputs[$InputKey].Elements[InputText/Index/$SelectedIndex].Text</DirectPath>
 		<DirectValueType>String</DirectValueType>
@@ -1985,7 +1985,7 @@ SelectedIndex or SelectedName can be used to select image.
 		</Description>
 		<Function>SetImage</Function>
 		<ValueName>Filename</ValueName>
-		<FormatString>Function=SetImage&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetImage&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 		<DirectPath>Inputs[$InputKey].Elements[InputImage/Index/$SelectedIndex].Image</DirectPath>
 		<DirectValueType>String</DirectValueType>
@@ -1998,7 +1998,7 @@ SelectedIndex or SelectedName can be used to select image.
 SelectedIndex or SelectedName can be used to select image.
 		</Description>
 		<Function>SetImageVisible</Function>
-		<FormatString>Function=SetImageVisible&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetImageVisible&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 	</vMixNewFunctionReference>
 
@@ -2007,7 +2007,7 @@ SelectedIndex or SelectedName can be used to select image.
 SelectedIndex or SelectedName can be used to select image.
 		</Description>
 		<Function>SetImageVisibleOn</Function>
-		<FormatString>Function=SetImageVisibleOn&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetImageVisibleOn&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 	</vMixNewFunctionReference>
 
@@ -2016,7 +2016,7 @@ SelectedIndex or SelectedName can be used to select image.
 SelectedIndex or SelectedName can be used to select image.
 		</Description>
 		<Function>SetImageVisibleOff</Function>
-		<FormatString>Function=SetImageVisibleOff&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetImageVisibleOff&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 	</vMixNewFunctionReference>
 
@@ -2033,7 +2033,7 @@ SelectedIndex or SelectedName can be used to select image.
 SelectedIndex or SelectedName can be used to select text field.
 		</Description>
 		<Function>SetTextVisible</Function>
-		<FormatString>Function=SetTextVisible&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetTextVisible&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 	</vMixNewFunctionReference>
 
@@ -2042,7 +2042,7 @@ SelectedIndex or SelectedName can be used to select text field.
 SelectedIndex or SelectedName can be used to select text field.
 		</Description>
 		<Function>SetTextVisibleOn</Function>
-		<FormatString>Function=SetTextVisibleOn&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetTextVisibleOn&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 	</vMixNewFunctionReference>
 
@@ -2051,7 +2051,7 @@ SelectedIndex or SelectedName can be used to select text field.
 SelectedIndex or SelectedName can be used to select text field.
 		</Description>
 		<Function>SetTextVisibleOff</Function>
-		<FormatString>Function=SetTextVisibleOff&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetTextVisibleOff&amp;Input=$InputKey&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 	</vMixNewFunctionReference>
 
@@ -2061,7 +2061,7 @@ SelectedIndex or SelectedName can be used to select ticker field.
 		</Description>
 		<Function>SetTickerSpeed</Function>
 		<ValueName>Speed 0-1000</ValueName>
-		<FormatString>Function=SetTickerSpeed&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetTickerSpeed&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 		<NumericValue>Float</NumericValue>
 	</vMixNewFunctionReference>
@@ -2072,7 +2072,7 @@ SelectedIndex or SelectedName can be used to select object.
 		</Description>
 		<Function>SetColor</Function>
 		<ValueName>Color</ValueName>
-		<FormatString>Function=SetColor&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex</FormatString>
+		<FormatString>Function=SetColor&amp;Input=$InputKey&amp;Value=$Value&amp;SelectedIndex=$SelectedIndex&amp;SelectedName=$SelectedName</FormatString>
 		<Category>Title</Category>
 	</vMixNewFunctionReference>
 

--- a/vMixController/PropertiesControls/NewScriptControl.xaml
+++ b/vMixController/PropertiesControls/NewScriptControl.xaml
@@ -172,6 +172,9 @@
                                                                 </Button>
                                                             </Grid>
 
+                                                            <Label x:Name="NameLabel" Content="{loc:Loc Key=ScriptEditor.Field.Name}"/>
+                                                            <TextBox x:Name="Name" TextWrapping="Wrap" Style="{StaticResource WidgetTextBox}" Text="{Binding SelectedName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
                                                             <Label x:Name="DurationLabel" Content="{loc:Loc Key=ScriptEditor.Field.Duration}"/>
                                                             <TextBox x:Name="Duration" TextWrapping="Wrap" Style="{StaticResource WidgetTextBox}" Text="{Binding Duration, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
@@ -190,6 +193,10 @@
                                                             <DataTrigger Binding="{Binding SelectedValue.HasIndex, ElementName=Func, FallbackValue=False}" Value="False">
                                                                 <Setter TargetName="IndexLabel" Property="Visibility" Value="Collapsed"/>
                                                                 <Setter TargetName="Index" Property="Visibility" Value="Collapsed"/>
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding SelectedValue.HasSelectedName, ElementName=Func, FallbackValue=False}" Value="False">
+                                                                <Setter TargetName="NameLabel" Property="Visibility" Value="Collapsed"/>
+                                                                <Setter TargetName="Name" Property="Visibility" Value="Collapsed"/>
                                                             </DataTrigger>
                                                             <DataTrigger Binding="{Binding SelectedValue.HasInput, ElementName=Func, FallbackValue=False}" Value="False">
                                                                 <Setter TargetName="InputLabel" Property="Visibility" Value="Collapsed"/>

--- a/vMixController/Skins/ControlTemplates.xaml
+++ b/vMixController/Skins/ControlTemplates.xaml
@@ -735,7 +735,7 @@
         </ContentPresenter>
     </Grid>
 
-    <ctrls:ComboBox VirtualizingStackPanel.IsVirtualizing="True"  Style="{DynamicResource {x:Type ComboBox}}" IsEditable="{Binding IsEditable}" HorizontalContentAlignment="Stretch" x:Shared="false" x:Key="ListWidgetControl" Margin="{StaticResource StdMargin}" ItemsSource="{Binding Items}" Grid.Column="1" Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" e:FocusExtension.IsFocused="{Binding IsFocused}" d:DataContext="{d:DesignInstance widget:vMixControlList}">
+    <ctrls:ComboBox VirtualizingStackPanel.IsVirtualizing="True"  Style="{DynamicResource {x:Type ComboBox}}" IsEditable="{Binding IsEditable}" HorizontalContentAlignment="Stretch" x:Shared="false" x:Key="ListWidgetControl" Margin="{StaticResource StdMargin}" ItemsSource="{Binding Items}" Grid.Column="1" Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" e:FocusExtension.IsFocused="{Binding IsFocused}" d:DataContext="{d:DesignInstance widget:vMixControlList}">
         <ComboBox.ItemsPanel>
             <ItemsPanelTemplate>
                 <VirtualizingStackPanel />

--- a/vMixController/Skins/PropertyEditorTemplates.xaml
+++ b/vMixController/Skins/PropertyEditorTemplates.xaml
@@ -119,6 +119,7 @@
             <prop:IntControl Value="{Binding Period, Mode=TwoWay, UpdateSourceTrigger=Explicit}" Title="{loc:Loc Key=PropertyEditor.ExternalData.UpdatePeriod}"/>
             <prop:FilePathControl Title="{loc:Loc Key=PropertyEditor.FileDialog.Title}" Filter="{loc:Loc Key=PropertyEditor.FileDialog.ExternalDataFilter}" Value="{Binding DataProviderPath, Mode=TwoWay, UpdateSourceTrigger=Explicit}"/>
             <prop:BoolControl Value="{Binding RestartData, Mode=TwoWay, UpdateSourceTrigger=Explicit}" Title="{loc:Loc Key=PropertyEditor.ExternalData.LoopData}"/>
+            <prop:StringControl Value="{Binding SelectionSourceName, Mode=TwoWay, UpdateSourceTrigger=Explicit}" Title="{loc:Loc Key=PropertyEditor.ExternalData.SelectionSource}"/>
             <prop:TitleMappingControl Titles="{Binding Paths, UpdateSourceTrigger=Explicit, Mode=TwoWay}"/>
         </StackPanel>
     </DataTemplate>
@@ -192,6 +193,7 @@
                 <prop:BoolControl Grouped="True" Grid.Column="1" Title="{loc:Loc Key=PropertyEditor.Timer.HighPrecision}" Help="{loc:Loc Key=PropertyEditor.Timer.HighPrecision.Help}" Value="{Binding IsHighPrecision, Mode=TwoWay, UpdateSourceTrigger=Explicit}"/>
                 <prop:BoolControl Grouped="True" Grid.Column="2" Title="{loc:Loc Key=PropertyEditor.Timer.RecoverOnSync}" Help="{loc:Loc Key=PropertyEditor.Timer.RecoverOnSync.Help}" Value="{Binding RecoverOnSync, Mode=TwoWay, UpdateSourceTrigger=Explicit}"/>
             </Grid>
+            <prop:BoolControl Value="{Binding DisplayZeroWhenStopped, Mode=TwoWay, UpdateSourceTrigger=Explicit}" Title="{loc:Loc Key=PropertyEditor.Timer.DisplayZeroWhenStopped}" Help="{loc:Loc Key=PropertyEditor.Timer.DisplayZeroWhenStopped.Help}"/>
             <prop:LabelControl Title="{loc:Loc Key=PropertyEditor.Timer.Events}" Help="{loc:Loc Key=PropertyEditor.Timer.Events.Help}"/>
             <prop:StringControl Title="{loc:Loc Key=PropertyEditor.Timer.OnStart}" Value="{Binding Links[0], Mode=TwoWay, UpdateSourceTrigger=Explicit}"/>
             <prop:StringControl Title="{loc:Loc Key=PropertyEditor.Timer.OnPause}" Value="{Binding Links[1], Mode=TwoWay, UpdateSourceTrigger=Explicit}"/>

--- a/vMixController/Widgets/vMixControlButton.cs
+++ b/vMixController/Widgets/vMixControlButton.cs
@@ -923,13 +923,16 @@ namespace vMixController.Widgets
             var inputNumberByKey = state?.Inputs?.GroupBy(x => x.Key)
                 .ToDictionary(g => g.Key, g => (int?)g.First().Number)
                 ?? new Dictionary<string, int?>();
-            for (int _pointer = 0; _pointer < _commands.Count; _pointer++)
+            // Снимок коллекции команд, чтобы её изменение пользователем во время выполнения
+            // не приводило к InvalidOperationException при обращении к ObservableCollection.
+            var commands = _commands.ToList();
+            for (int _pointer = 0; _pointer < commands.Count; _pointer++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 int parameter = 0;
                 string strparameter = "";
                 bool? conditionResult = null;
-                var cmd = _commands[_pointer];
+                var cmd = commands[_pointer];
                 object cachedObjectParameter = null;
                 bool cachedObjectParameterSet = false;
                 object GetObjectParameter()

--- a/vMixController/Widgets/vMixControlClock.cs
+++ b/vMixController/Widgets/vMixControlClock.cs
@@ -84,11 +84,11 @@ namespace vMixController.Widgets
 
         private void UpdateSortedEvents()
         {
-            _sortedEvents = Events.OrderBy(x => x.TimeOfDay).ToList();
+            _sortedEvents = Events.OrderBy(x => x.TimeOfDay.TimeOfDay).ToList();
             _firedEventsToday.Clear(); // Сброс сработавших событий при любом изменении расписания
             foreach (var ev in _sortedEvents)
             {
-                if (ev.Days.HasFlag(ToDaysOfWeek(DateTime.Now.DayOfWeek)) && ev.TimeOfDay <= DateTime.Now)
+                if (ev.Days.HasFlag(ToDaysOfWeek(DateTime.Now.DayOfWeek)) && ev.TimeOfDay.TimeOfDay <= DateTime.Now.TimeOfDay)
                 {
                     _firedEventsToday.Add(ev); // Помечаем все события, которые уже должны были сработать сегодня
                     Debug.Print($"Event '{ev.Command}' at {ev.TimeOfDay} marked as fired on update.");
@@ -166,7 +166,7 @@ namespace vMixController.Widgets
             // Ищем событие сегодня, но позже текущего времени
             foreach (var ev in _sortedEvents)
             {
-                if (ev.Days.HasFlag(ToDaysOfWeek(now.DayOfWeek)) && ev.TimeOfDay > now)
+                if (ev.Days.HasFlag(ToDaysOfWeek(now.DayOfWeek)) && ev.TimeOfDay.TimeOfDay > now.TimeOfDay)
                     return (ev, now);
             }
 

--- a/vMixController/Widgets/vMixControlExternalData.cs
+++ b/vMixController/Widgets/vMixControlExternalData.cs
@@ -83,6 +83,31 @@ namespace vMixController.Widgets
             }
         }
 
+        private string _selectionSourceName = "";
+
+        /// <summary>
+        /// Sets and gets the SelectionSourceName property.
+        /// Changes to that property's value raise the PropertyChanged event. 
+        /// </summary>
+        public string SelectionSourceName
+        {
+            get
+            {
+                return _selectionSourceName;
+            }
+
+            set
+            {
+                if (_selectionSourceName == value)
+                {
+                    return;
+                }
+
+                _selectionSourceName = value;
+                RaisePropertyChanged(nameof(SelectionSourceName));
+            }
+        }
+
         public vMixControlExternalData()
         {
             Data = new ObservableCollection<string>();
@@ -342,11 +367,19 @@ namespace vMixController.Widgets
                         if (State == null)
                             return;
 
+                        int offset = 0;
+                        if (!string.IsNullOrWhiteSpace(SelectionSourceName))
+                        {
+                            var listWidget = Singleton<SharedData>.Instance.GetDataSource(SelectionSourceName) as vMixControlList;
+                            if (listWidget != null && listWidget.SelectedIndex >= 0)
+                                offset = listWidget.SelectedIndex;
+                        }
+
                         for (int i = 0; i < pathsSnapshot.Length; i++)
                         {
                             var item = pathsSnapshot[i];
-                            var value = values[i % values.Length];
-                            if (!_restartData && i >= values.Length)
+                            var value = values[(offset + i) % values.Length];
+                            if (!_restartData && offset + i >= values.Length)
                                 value = "";
 
                             if (value.StartsWith("@[cmd]"))

--- a/vMixController/Widgets/vMixControlList.cs
+++ b/vMixController/Widgets/vMixControlList.cs
@@ -42,6 +42,27 @@ namespace vMixController.Widgets
             DependencyProperty.Register("Items", typeof(ObservableCollection<string>), typeof(vMixControlList), new PropertyMetadata(new ObservableCollection<string>()));
 
 
+        /// <summary>
+        /// Sets and gets the SelectedIndex property.
+        /// Changes to that property's value raise the PropertyChanged event. 
+        /// </summary>
+        public int SelectedIndex
+        {
+            get
+            {
+                return (int)GetValue(SelectedIndexProperty);
+            }
+
+            set
+            {
+                SetValue(SelectedIndexProperty, value);
+            }
+        }
+
+        // Using a DependencyProperty as the backing store for SelectedIndex.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty SelectedIndexProperty =
+            DependencyProperty.Register("SelectedIndex", typeof(int), typeof(vMixControlList), new PropertyMetadata(-1));
+
         public Triple<string, string, bool> DataSource { get; set; }
 
         public override void BeforePropertiesChanged()

--- a/vMixController/Widgets/vMixControlMidiInterface.cs
+++ b/vMixController/Widgets/vMixControlMidiInterface.cs
@@ -17,6 +17,8 @@ namespace vMixController.Widgets
     public class vMixControlMidiInterface : vMixControl
     {
         private static Dictionary<int, Melanchall.DryWetMidi.Multimedia.InputDevice> _openedDevices = new Dictionary<int, Melanchall.DryWetMidi.Multimedia.InputDevice>();
+        private static Dictionary<int, int> _deviceRefCounts = new Dictionary<int, int>();
+        private int _subscribedDeviceIndex = -1;
 
         private ObservableCollection<MidiInterfaceKey> _midis = new ObservableCollection<MidiInterfaceKey>();
 
@@ -130,9 +132,8 @@ namespace vMixController.Widgets
 
                 if (Device != null)
                 {
-                    Device.EventReceived += Device_EventReceived;
-                    if (!Device.IsListeningForEvents)
-                        Device.StartEventsListening();
+                    var idx = Array.IndexOf(MidiDevices, _midiDeviceName);
+                    SubscribeToDevice(Device, idx);
                 }
             }
         }
@@ -140,7 +141,7 @@ namespace vMixController.Widgets
         private void Device_EventReceived(object sender, Melanchall.DryWetMidi.Multimedia.MidiEventReceivedEventArgs e)
         {
 
-            Dispatcher.Invoke(() =>
+            Dispatcher.BeginInvoke(new Action(() =>
             {
                 foreach (var item in Midis)
                 {
@@ -150,6 +151,9 @@ namespace vMixController.Widgets
                         case Melanchall.DryWetMidi.Core.MidiEventType.NoteOn:
                         case Melanchall.DryWetMidi.Core.MidiEventType.NoteAftertouch:
                             var note = (e.Event as Melanchall.DryWetMidi.Core.NoteEvent);
+                            if (item.D != e.Event.EventType) break;
+                            if (e.Event.EventType == Melanchall.DryWetMidi.Core.MidiEventType.NoteOn && note.Velocity == 0)
+                                break;
                             if (note.Channel == item.A && item.B == note.NoteNumber)
                                 Messenger.Default.Send(new HotkeyLinkMessage() { Link = item.C, Parameter = ScriptExecutionDispatchRuntime.CreateOutgoingParameter((byte)note.Velocity) });
                             break;
@@ -173,7 +177,7 @@ namespace vMixController.Widgets
                             break;
                     }
                 }
-            });
+            }));
         }
 
         private Melanchall.DryWetMidi.Multimedia.InputDevice CreateDeviceByName(string name)
@@ -201,6 +205,30 @@ namespace vMixController.Widgets
             }
         }
 
+        private void SubscribeToDevice(Melanchall.DryWetMidi.Multimedia.InputDevice device, int index)
+        {
+            if (device == null) return;
+            device.EventReceived -= Device_EventReceived;
+            device.EventReceived += Device_EventReceived;
+            if (_subscribedDeviceIndex != index)
+            {
+                if (_subscribedDeviceIndex >= 0)
+                {
+                    if (_deviceRefCounts.TryGetValue(_subscribedDeviceIndex, out var old))
+                    {
+                        if (old <= 1)
+                            _deviceRefCounts.Remove(_subscribedDeviceIndex);
+                        else
+                            _deviceRefCounts[_subscribedDeviceIndex] = old - 1;
+                    }
+                }
+                _subscribedDeviceIndex = index;
+                _deviceRefCounts[index] = _deviceRefCounts.TryGetValue(index, out var cur) ? cur + 1 : 1;
+            }
+            if (!device.IsListeningForEvents)
+                device.StartEventsListening();
+        }
+
         public vMixControlMidiInterface()
         {
             Learn = () =>
@@ -224,10 +252,8 @@ namespace vMixController.Widgets
             Device = CreateDeviceByName(_midiDeviceName);
             if (Device != null)
             {
-                if (!Device.IsListeningForEvents)
-                    Device.StartEventsListening();
-                Device.EventReceived += Device_EventReceived;
-
+                var idx = Array.IndexOf(MidiDevices, _midiDeviceName);
+                SubscribeToDevice(Device, idx);
             }
             base.BeforePropertiesChanged();
         }
@@ -248,7 +274,20 @@ namespace vMixController.Widgets
             if (managed)
             {
                 if (Device != null)
+                {
                     Device.EventReceived -= Device_EventReceived;
+                    if (_subscribedDeviceIndex >= 0 && _deviceRefCounts.TryGetValue(_subscribedDeviceIndex, out var c))
+                    {
+                        if (c <= 1)
+                        {
+                            _deviceRefCounts.Remove(_subscribedDeviceIndex);
+                            if (Device.IsListeningForEvents)
+                                Device.StopEventsListening();
+                        }
+                        else
+                            _deviceRefCounts[_subscribedDeviceIndex] = c - 1;
+                    }
+                }
                 base.Dispose(managed);
                 GC.SuppressFinalize(this);
             }

--- a/vMixController/Widgets/vMixControlNewButton.cs
+++ b/vMixController/Widgets/vMixControlNewButton.cs
@@ -582,8 +582,7 @@ namespace vMixController.Widgets
 
             try
             {
-                //await Task.Run(() => ExecutionThread((object)state, cancellationToken), cancellationToken);
-                await ExecutionThread((object)state, cancellationToken);
+                await Task.Run(() => ExecutionThread((object)state, cancellationToken), cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -898,13 +897,16 @@ namespace vMixController.Widgets
             var inputNumberByKey = state?.Inputs?.GroupBy(x => x.Key)
                 .ToDictionary(g => g.Key, g => (int?)g.First().Number)
                 ?? new Dictionary<string, int?>();
-            for (int _pointer = 0; _pointer < _commands.Count; _pointer++)
+            // Снимок коллекции команд, чтобы её изменение пользователем во время выполнения
+            // не приводило к InvalidOperationException при обращении к ObservableCollection.
+            var commands = _commands.ToList();
+            for (int _pointer = 0; _pointer < commands.Count; _pointer++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 int parameter = 0;
                 string strparameter = "";
                 bool? conditionResult = null;
-                var cmd = _commands[_pointer];
+                var cmd = commands[_pointer];
                 object cachedObjectParameter = null;
                 bool cachedObjectParameterSet = false;
                 object GetObjectParameter()
@@ -1117,7 +1119,7 @@ namespace vMixController.Widgets
                             index,
                             cmd.Mix, cmd.Channel, cmd.Duration);
 
-                        var command = cmd.Action.FormatString.ReplacePlaceholdersFromObject(formatter);
+                        var command = (cmd.Action.FormatString ?? string.Empty).ReplacePlaceholdersFromObject(formatter);
 
                         if (string.IsNullOrWhiteSpace(cmd.Action.DirectPath))
                             AddLog("{2}) SEND {0} WITH RESULT {1}", command, state.SendFunction(command, false, timeout: cmd.Action.Timeout), _pointer + 1);
@@ -1126,7 +1128,7 @@ namespace vMixController.Widgets
                             vMixControlButtonHelper.CalculateExpression(cmd.Value, PopulateVariables, ExpressionEvaluateFunction, out int p1);
 
 
-                            var path = cmd.Action.DirectPath.ReplacePlaceholdersFromObject(formatter);//string.Format(cmd.Action.DirectPath, key, p1, Dispatcher.Invoke(() => CalculateObjectParameter(cmd)), p1 - 1, input ?? 0, string.IsNullOrWhiteSpace(key) ? "" : "Input=");
+                            var path = (cmd.Action.DirectPath ?? string.Empty).ReplacePlaceholdersFromObject(formatter);//string.Format(cmd.Action.DirectPath, key, p1, Dispatcher.Invoke(() => CalculateObjectParameter(cmd)), p1 - 1, input ?? 0, string.IsNullOrWhiteSpace(key) ? "" : "Input=");
                             object value;
                             switch (cmd.Action.DirectValueType)
                             {

--- a/vMixController/Widgets/vMixControlNewButton.cs
+++ b/vMixController/Widgets/vMixControlNewButton.cs
@@ -1112,16 +1112,19 @@ namespace vMixController.Widgets
                         }
 
                         vMixControlButtonHelper.CalculateExpression(cmd.SelectedIndex, PopulateVariables, ExpressionEvaluateFunction, out string index);
+                        vMixControlButtonHelper.CalculateExpression(cmd.SelectedName, PopulateVariables, ExpressionEvaluateFunction, out string selectedName);
+                        if (string.IsNullOrEmpty(selectedName))
+                            selectedName = cmd.SelectedName;
 
                         var formatter = new XPathNewFormattingArgs(key, input.HasValue ? input.Value : -2,
                             cmd.Action.NumericValue == NumericValueType.Integer ? ((int)calculatedParameter).ToString(CultureInfo.InvariantCulture) :
                             (cmd.Action.NumericValue == NumericValueType.Float ? ((float)calculatedParameter).ToString(CultureInfo.InvariantCulture) : (string)calculatedParameter),
-                            index,
+                            index, selectedName,
                             cmd.Mix, cmd.Channel, cmd.Duration);
 
                         var command = (cmd.Action.FormatString ?? string.Empty).ReplacePlaceholdersFromObject(formatter);
 
-                        if (string.IsNullOrWhiteSpace(cmd.Action.DirectPath))
+                        if (string.IsNullOrWhiteSpace(cmd.Action.DirectPath) || !string.IsNullOrWhiteSpace(cmd.SelectedName))
                             AddLog("{2}) SEND {0} WITH RESULT {1}", command, state.SendFunction(command, false, timeout: cmd.Action.Timeout), _pointer + 1);
                         else
                         {

--- a/vMixController/Widgets/vMixControlTextField.cs
+++ b/vMixController/Widgets/vMixControlTextField.cs
@@ -64,7 +64,8 @@ namespace vMixController.Widgets
             lock (_pendingUpdates) // Защита от одновременного доступа к словарю и очереди
             {
                 // Проходим по элементам в очереди для обработки
-                while (_updateQueue.Count > 0)
+                var skipped = 0;
+                while (_updateQueue.Count > 0 && skipped < _updateQueue.Count)
                 {
                     var key = _updateQueue.Peek(); // Смотрим на первый элемент, не удаляя его
 
@@ -75,11 +76,13 @@ namespace vMixController.Widgets
                         _queuedKeys.Remove(key);
                         _pendingUpdates.Remove(key); // Удаляем из словаря
                         itemsToProcess.Add(key); // Добавляем в список для обработки
+                        skipped = 0;
                     }
                     else
                     {
-                        // Если еще не пришло время для первого элемента, то и для последующих тоже
-                        break;
+                        // Если еще не пришло время, перемещаем в конец очереди, не блокируя остальные
+                        _updateQueue.Enqueue(_updateQueue.Dequeue());
+                        skipped++;
                     }
                 }
             }

--- a/vMixController/Widgets/vMixControlTimer.cs
+++ b/vMixController/Widgets/vMixControlTimer.cs
@@ -207,6 +207,31 @@ namespace vMixController.Widgets
             set => SetPropertyValue(ref _recoverOnSync, value, nameof(RecoverOnSync));
         }
 
+        private bool _displayZeroWhenStopped = true;
+
+        /// <summary>
+        /// Sets and gets the DisplayZeroWhenStopped property.
+        /// Changes to that property's value raise the PropertyChanged event. 
+        /// </summary>
+        public bool DisplayZeroWhenStopped
+        {
+            get
+            {
+                return _displayZeroWhenStopped;
+            }
+
+            set
+            {
+                if (_displayZeroWhenStopped == value)
+                {
+                    return;
+                }
+
+                _displayZeroWhenStopped = value;
+                RaisePropertyChanged(nameof(DisplayZeroWhenStopped));
+            }
+        }
+
         private string _format = @"hh\:mm\:ss";
 
         /// <summary>
@@ -327,7 +352,8 @@ namespace vMixController.Widgets
                 if (!_changingTime && _recoverOnSync)
                 {
                     TimeSpan parsed = TimeSpan.Zero;
-                    if (TimeSpan.TryParseExact((string)e.NewValue, _format, CultureInfo.InvariantCulture, out parsed))
+                    if (TimeSpan.TryParseExact((string)e.NewValue, _format, CultureInfo.InvariantCulture, out parsed)
+                        || TimeSpan.TryParseExact((string)e.NewValue, @"mm\:ss", CultureInfo.InvariantCulture, out parsed))
                     //if (TimeSpan.TryParse((string)e.NewValue, out parsed))
                     {
                         _time = parsed;
@@ -434,7 +460,8 @@ namespace vMixController.Widgets
                     else
                         StopWorker(resetPhase: true);
                     Paused = false;
-                    UpdateTimer();
+                    if (DisplayZeroWhenStopped)
+                        UpdateTimer();
                     SendLink(Constants.TIMER_EVENT_ONSTOP);
                     break;
                 case "+1 Hour":

--- a/vMixControllerSkin/Properties/Strings.resx
+++ b/vMixControllerSkin/Properties/Strings.resx
@@ -518,6 +518,9 @@ Use Momentary buttons for this type of scripts.</value>
   <data name="PropertyEditor.ExternalData.LoopData" xml:space="preserve">
     <value>Loop Data</value>
   </data>
+  <data name="PropertyEditor.ExternalData.SelectionSource" xml:space="preserve">
+    <value>Selection source (List widget name)</value>
+  </data>
   <data name="PropertyEditor.Timer.SplitText" xml:space="preserve">
     <value>Split Text</value>
   </data>
@@ -535,6 +538,12 @@ Use Momentary buttons for this type of scripts.</value>
   </data>
   <data name="PropertyEditor.Timer.RecoverOnSync.Help" xml:space="preserve">
     <value>Recover timer value from vMix state on sync, it can not work with some format strings</value>
+  </data>
+  <data name="PropertyEditor.Timer.DisplayZeroWhenStopped" xml:space="preserve">
+    <value>Display 00:00:00 when stopped</value>
+  </data>
+  <data name="PropertyEditor.Timer.DisplayZeroWhenStopped.Help" xml:space="preserve">
+    <value>When disabled, timer keeps showing current time after stop</value>
   </data>
   <data name="PropertyEditor.Timer.Events" xml:space="preserve">
     <value>Events</value>

--- a/vMixControllerSkin/Properties/Strings.resx
+++ b/vMixControllerSkin/Properties/Strings.resx
@@ -686,6 +686,9 @@ Use Momentary buttons for this type of scripts.</value>
   <data name="ScriptEditor.Field.Index" xml:space="preserve">
     <value>Index</value>
   </data>
+  <data name="ScriptEditor.Field.Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
   <data name="ScriptEditor.Field.Duration" xml:space="preserve">
     <value>Duration</value>
   </data>

--- a/vMixControllerSkin/Properties/Strings.ru-RU.resx
+++ b/vMixControllerSkin/Properties/Strings.ru-RU.resx
@@ -518,6 +518,9 @@
   <data name="PropertyEditor.ExternalData.LoopData" xml:space="preserve">
     <value>Зациклить данные</value>
   </data>
+  <data name="PropertyEditor.ExternalData.SelectionSource" xml:space="preserve">
+    <value>Источник выбора (имя виджета списка)</value>
+  </data>
   <data name="PropertyEditor.Timer.SplitText" xml:space="preserve">
     <value>Разделить текст</value>
   </data>
@@ -535,6 +538,12 @@
   </data>
   <data name="PropertyEditor.Timer.RecoverOnSync.Help" xml:space="preserve">
     <value>Восстановить значение таймера из состояния vMix при синхронизации, может работать не со всеми строками форматирования</value>
+  </data>
+  <data name="PropertyEditor.Timer.DisplayZeroWhenStopped" xml:space="preserve">
+    <value>Показывать 00:00:00 при остановке</value>
+  </data>
+  <data name="PropertyEditor.Timer.DisplayZeroWhenStopped.Help" xml:space="preserve">
+    <value>Если выключено, таймер сохраняет текущее время после остановки</value>
   </data>
   <data name="PropertyEditor.Timer.Events" xml:space="preserve">
     <value>События</value>

--- a/vMixControllerSkin/Properties/Strings.ru-RU.resx
+++ b/vMixControllerSkin/Properties/Strings.ru-RU.resx
@@ -686,6 +686,9 @@
   <data name="ScriptEditor.Field.Index" xml:space="preserve">
     <value>Индекс</value>
   </data>
+  <data name="ScriptEditor.Field.Name" xml:space="preserve">
+    <value>Имя</value>
+  </data>
   <data name="ScriptEditor.Field.Duration" xml:space="preserve">
     <value>Продолжительность</value>
   </data>

--- a/vMixControllerSkin/Properties/Strings.zh-CN.resx
+++ b/vMixControllerSkin/Properties/Strings.zh-CN.resx
@@ -686,6 +686,9 @@
   <data name="ScriptEditor.Field.Index" xml:space="preserve">
     <value>索引</value>
   </data>
+  <data name="ScriptEditor.Field.Name" xml:space="preserve">
+    <value>名称</value>
+  </data>
   <data name="ScriptEditor.Field.Duration" xml:space="preserve">
     <value>时长</value>
   </data>

--- a/vMixControllerSkin/Properties/Strings.zh-CN.resx
+++ b/vMixControllerSkin/Properties/Strings.zh-CN.resx
@@ -518,6 +518,9 @@
   <data name="PropertyEditor.ExternalData.LoopData" xml:space="preserve">
     <value>循环数据</value>
   </data>
+  <data name="PropertyEditor.ExternalData.SelectionSource" xml:space="preserve">
+    <value>选择来源（列表控件名称）</value>
+  </data>
   <data name="PropertyEditor.Timer.SplitText" xml:space="preserve">
     <value>拆分文本</value>
   </data>
@@ -535,6 +538,12 @@
   </data>
   <data name="PropertyEditor.Timer.RecoverOnSync.Help" xml:space="preserve">
     <value>同步时从 vMix 状态恢复计时器值，某些格式字符串下可能无法工作。</value>
+  </data>
+  <data name="PropertyEditor.Timer.DisplayZeroWhenStopped" xml:space="preserve">
+    <value>停止时显示 00:00:00</value>
+  </data>
+  <data name="PropertyEditor.Timer.DisplayZeroWhenStopped.Help" xml:space="preserve">
+    <value>关闭后，停止时保留当前时间显示。</value>
   </data>
   <data name="PropertyEditor.Timer.Events" xml:space="preserve">
     <value>事件</value>


### PR DESCRIPTION
## Summary

Two regressions introduced by the 2025 AI-assisted rewrites are fixed here. Both break documented workflows for real users; both were verified against the 2023 master-GUID version where they worked correctly.

## Changes (3 files, minimal diffs)

| File | Change |
|------|--------|
| `vMixAPI/State.cs` | Escape `#` to `%23` before building the function URL (+1 line) |
| `vMixController/Widgets/vMixControlTextField.cs` | Rotate a not-yet-calm queue head instead of breaking out of the loop (+3 lines) |
| `vMixController/NewFunctions.xml` | Drop the ineffective `SelectedIndex` parameter from SetTextColour (1 line) |

## Why this matters

### 1. Colour functions silently fail for everyone who follows the docs

Since the 2025 scripting rewrite, commands are built via FormatString templates and sent through `SendFunction(string)`, which concatenates the URL **without URL-encoding**. The previous system sent commands through `SendFunction(params)`, which called `HttpUtility.UrlEncode` on every value. vMix's TCP API documentation explicitly requires URL-escaped parameters, and SetTextColour / SetColor document the colour format as `#xxxxxx` / `#xxxxxxxx`.

Result: the `#` in `Value=#FF0000` is treated as a URL fragment and never reaches vMix, so colour commands never work when used as documented. Users reported this twice (issue #68/#70 and tutorial comments), including "text disappears and colour does not change" — a corrupted `Value` reaches vMix.

The fix escapes only `#` (`&` and `=` keep their separator meaning), restoring parity with the old encoded path.

### 2. The delayed write-back queue can stall every text widget

The 2025-10-29 coalescing queue (the #56 fix) breaks when the head element is not "calm" for 0.1s. After coalescing, a busy head key keeps refreshing its timestamp **in place**, so a high-frequency widget (e.g. ExternalData with Period=100ms driving a shared vMix field) never becomes calm — and everything behind it in the queue never gets `UpdateSource()`. This is the likely residual "Sync freezes" reported in #56.

The fix rotates the not-yet-calm head to the tail and keeps processing; a skipped counter prevents busy looping. Coalescing and the 0.1s debounce semantics are unchanged.

### 3. Cleanup

vMix documents only Value and Input for SetTextColour (SelectedIndex belongs to SetText / SetImage / SetColor). The extra parameter was silently ignored by vMix and misled users — removed.

## Testing (done on vMix 28 Pro)

- `SetTextColour` with `#FF0000` → GT title text turns red (previously: no effect)
- ExternalData (Period=100) + two TextFields sharing/not sharing fields → the second widget writes back normally (previously: stalled)
- Regression: single-widget typing, table mode concatenation, 0.1s debounce merge, parameter boxes — all unchanged
- Note: SetColor has no effect on GT titles (vMix behaviour; works on regular Title inputs only) — worth documenting

## Dependencies

Builds on PR #1 (community fixes, already submitted). Order: PR #1 → this PR → PR #3 (SelectedName feature).
